### PR TITLE
Add 24 new papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,3 +826,142 @@ May 2021
 ## About
 This list is automatically generated and updated daily.
 
+---
+
+# More Papers
+
+
+## Foundational
+
+**Towards Hierarchical Rectified Flow**\
+*Yichi Zhang, Yici Yan, Alex Schwing, Zhizhen Zhao*\
+International Conference on Learning Representations 2025. (cited: 10) [[Paper](https://arxiv.org/abs/2502.17436)]\
+Feb 2025
+
+
+## Discrete Data
+
+**Any-Order Flexible Length Masked Diffusion**\
+*Jaeyeon Kim, C. Lee, Carles Domingo-Enrich, Yilun Du, S. Kakade, et al.*\
+arXiv.org 2025. (cited: 17) [[Paper](https://arxiv.org/abs/2509.01025)]\
+Sep 2025
+
+
+## Accelerating
+
+**PeRFlow: Piecewise Rectified Flow as Universal Plug-and-Play Accelerator**\
+*Hanshu Yan, Xingchao Liu, Jiachun Pan, J. Liew, Qiang Liu, et al.*\
+Neural Information Processing Systems 2024. (cited: 78) [[Paper](https://arxiv.org/abs/2405.07510)]\
+May 2024
+
+**Rectified Diffusion: Straightness Is Not Your Need in Rectified Flow**\
+*Fu-Yun Wang, Ling Yang, Zhaoyang Huang, Mengdi Wang, Hongsheng Li*\
+International Conference on Learning Representations 2024. (cited: 48) [[Paper](https://arxiv.org/abs/2410.07303)]\
+Oct 2024
+
+**FireFlow: Fast Inversion of Rectified Flow for Image Semantic Editing**\
+*Yingying Deng, Xiangyu He, Changwang Mei, Peisong Wang, Fan Tang*\
+International Conference on Machine Learning 2024. (cited: 40) [[Paper](https://arxiv.org/abs/2412.07517)]\
+Dec 2024
+
+**SlimFlow: Training Smaller One-Step Diffusion Models with Rectified Flow**\
+*Yuanzhi Zhu, Xingchao Liu, Qiang Liu*\
+European Conference on Computer Vision 2024. (cited: 24) [[Paper](https://arxiv.org/abs/2407.12718)]\
+Jul 2024
+
+**Inference-Time Scaling for Flow Models via Stochastic Generation and Rollover Budget Forcing**\
+*Jaihoon Kim, Taehoon Yoon, Jisung Hwang, Minhyuk Sung*\
+arXiv.org 2025. (cited: 20) [[Paper](https://arxiv.org/abs/2503.19385)]\
+Mar 2025
+
+**Adjoint Matching: Fine-tuning Flow and Diffusion Generative Models with Memoryless Stochastic Optimal Control**\
+*Carles Domingo-Enrich, Michal Drozdzal, Brian Karrer, Ricky T. Q. Chen*\
+arXiv.org 2024. (cited: 120) [[Paper](https://arxiv.org/abs/2409.08861)]\
+Sep 2024
+
+**TO-FLOW: Efficient Continuous Normalizing Flows with Temporal Optimization adjoint with Moving Speed**\
+*Shian Du, Yihong Luo, Wei Chen, Jian Xu, Delu Zeng*\
+Computer Vision and Pattern Recognition 2022. (cited: 10) [[Paper](https://arxiv.org/abs/2203.10335)]\
+Mar 2022
+
+
+## Applications
+
+**TripoSG: High-Fidelity 3D Shape Synthesis using Large-Scale Rectified Flow Models**\
+*Yangguang Li, Zi-Xin Zou, Zexiang Liu, Dehu Wang, Yuan Liang, et al.*\
+IEEE Transactions on Pattern Analysis and Machine Intelligence 2025. (cited: 88) [[Paper](https://arxiv.org/abs/2502.06608)]\
+Feb 2025
+
+**Taming Rectified Flow for Inversion and Editing**\
+*Jiangshan Wang, Junfu Pu, Zhongang Qi, Jiayi Guo, Yue Ma, et al.*\
+International Conference on Machine Learning 2024. (cited: 114) [[Paper](https://arxiv.org/abs/2411.04746)]\
+Nov 2024
+
+**JanusFlow: Harmonizing Autoregression and Rectified Flow for Unified Multimodal Understanding and Generation**\
+*Yiyang Ma, Xingchao Liu, Xiaokang Chen, Wen Liu, Chengyue Wu, et al.*\
+Computer Vision and Pattern Recognition 2024. (cited: 86) [[Paper](https://arxiv.org/abs/2411.07975)]\
+Nov 2024
+
+**Frieren: Efficient Video-to-Audio Generation Network with Rectified Flow Matching**\
+*Yongqi Wang, Wenxiang Guo, Rongjie Huang, Jia-Bin Huang, Zehan Wang, et al.*\
+Neural Information Processing Systems 2024. (cited: 46) [[Paper](https://arxiv.org/abs/2406.00320)]\
+Jun 2024
+
+**FlowIE: Efficient Image Enhancement via Rectified Flow**\
+*Yixuan Zhu, Wenliang Zhao, Ao Li, Yansong Tang, Jie Zhou, et al.*\
+Computer Vision and Pattern Recognition 2024. (cited: 31) [[Paper](https://arxiv.org/abs/2406.00508)]\
+Jun 2024
+
+**FlowSep: Language-Queried Sound Separation with Rectified Flow Matching**\
+*Yiitan Yuan, Xubo Liu, Haohe Liu, Mark D. Plumbley, Wenwu Wang*\
+IEEE International Conference on Acoustics, Speech, and Signal Processing 2024. (cited: 25) [[Paper](https://arxiv.org/abs/2409.07614)]\
+Sep 2024
+
+**Posterior-Mean Rectified Flow: Towards Minimum MSE Photo-Realistic Image Restoration**\
+*Guy Ohayon, T. Michaeli, Michael Elad*\
+International Conference on Learning Representations 2024. (cited: 23) [[Paper](https://arxiv.org/abs/2410.00418)]\
+Oct 2024
+
+**EraseAnything: Enabling Concept Erasure in Rectified Flow Transformers**\
+*Daiheng Gao, Shilin Lu, Shaw Walters, Wenbo Zhou, Jiaming Chu, et al.*\
+arXiv.org 2024. (cited: 48) [[Paper](https://arxiv.org/abs/2412.20413)]\
+Dec 2024
+
+**Steering Rectified Flow Models in the Vector Field for Controlled Image Generation**\
+*Maitreya Patel, Song Wen, Dimitris N. Metaxas, Yezhou Yang*\
+arXiv.org 2024. (cited: 21) [[Paper](https://arxiv.org/abs/2412.00100)]\
+Dec 2024
+
+**Text-to-Image Rectified Flow as Plug-and-Play Priors**\
+*Xiaofeng Yang, Cheng Chen, Xulei Yang, Fayao Liu, Guosheng Lin*\
+International Conference on Learning Representations 2024. (cited: 23) [[Paper](https://arxiv.org/abs/2406.03293)]\
+Jun 2024
+
+**Don't Start From Scratch: Behavioral Refinement via Interpolant-based Policy Diffusion**\
+*Kaiqi Chen, Eugene Lim, Kelvin Lin, Yiyang Chen, Harold Soh*\
+Robotics: Science and Systems 2024. (cited: 19) [[Paper](https://arxiv.org/abs/2402.16075)]\
+Feb 2024
+
+**Multimarginal generative modeling with stochastic interpolants**\
+*M. S. Albergo, N. Boffi, Michael Lindsey, Eric Vanden-Eijnden*\
+International Conference on Learning Representations 2023. (cited: 15) [[Paper](https://arxiv.org/abs/2310.03695)]\
+Oct 2023
+
+**Lattice-based kernel approximation and serendipitous weights for parametric PDEs in very high dimensions**\
+*V. Kaarnioja, F. Kuo, I. Sloan*\
+arXiv.org 2023. (cited: 13) [[Paper](https://arxiv.org/abs/2303.17755)]\
+Mar 2023
+
+**Score-Based Generative Modeling through Stochastic Differential Equations**\
+*Yang Song, Jascha Narain Sohl-Dickstein, Diederik P. Kingma, Abhishek Kumar, Stefano Ermon, et al.*\
+International Conference on Learning Representations 2020. (cited: 9085) [[Paper](https://arxiv.org/abs/2011.13456)]\
+Nov 2020
+
+**Open Materials Generation with Stochastic Interpolants**\
+*Philipp Hoellmer, Thomas Egg, Maya M. Martirossyan, Eric Fuemmeler, Amit Gupta, et al.*\
+International Conference on Machine Learning 2025. (cited: 15) [[Paper](https://arxiv.org/abs/2502.02582)]\
+Feb 2025
+---
+## About
+This list is automatically generated and updated daily.
+


### PR DESCRIPTION
Automatically adding 24 new papers with 10+ citations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: README-only change that adds bibliographic entries and headings without affecting code or runtime behavior.
> 
> **Overview**
> Expands `README.md` by appending a new **“More Papers”** section after the auto-discovered list, adding 24 additional paper entries organized under *Foundational*, *Discrete Data*, *Accelerating*, and *Applications*.
> 
> The new section includes a separator and repeats the standard `## About` footer text at the end to match the existing auto-generated format.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a146c73f62283d11c38d9d34c708da71f8af7ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->